### PR TITLE
Making python3 explicit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(traffic_sim)
 
 
 find_package(catkin REQUIRED COMPONENTS
-  marine_msgs
+  project11_msgs
   project11
   rospy
 )

--- a/nodes/traffic_sim_node.py
+++ b/nodes/traffic_sim_node.py
@@ -1,9 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
-from builtins import str
-from builtins import range
-from builtins import object
 import rospy
 from geographic_msgs.msg import GeoPointStamped
 from nav_msgs.msg import Odometry

--- a/nodes/traffic_sim_node.py
+++ b/nodes/traffic_sim_node.py
@@ -7,7 +7,7 @@ from builtins import object
 import rospy
 from geographic_msgs.msg import GeoPointStamped
 from nav_msgs.msg import Odometry
-from marine_msgs.msg import Contact
+from project11_msgs.msg import Contact
 from sensor_msgs.msg import Joy
 import project11
 import random

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>rospy</depend>
-  <depend>marine_msgs</depend>
+  <depend>project11_msgs</depend>
   <depend>project11</depend>
   <export>
   </export>


### PR DESCRIPTION
Making python3 explicit in shebang and removing `from __future__` and `from builtins` imports from `.py` files.

The reasons for this are...

1. For our use-case we are using ROS-Noetic (Python 3) with older code that is Python 2, so need to be explicit with the interpreter. 
2. Noetic is exclusively Python 3, so including the imports can be confusing.